### PR TITLE
defensive when there is no DST in timezone

### DIFF
--- a/lib/redis/time_series/version.rb
+++ b/lib/redis/time_series/version.rb
@@ -2,6 +2,6 @@
 
 class Redis
   class TimeSeries
-    VERSION = "0.8.7"
+    VERSION = "0.8.8"
   end
 end


### PR DESCRIPTION
If there is no timezone set on the server, or a timezone that does not have the DST like the most of europe timezones then quite some graphs using this will fail. this is a fallback for when there is no DST. because then there does not need to be logic for that