### PR TITLE
RangeCmd.batch parity specs for every routing variant (v0.8.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.13
+* Batch/single parity specs for `RangeCmd.batch`: `filter_by_range` (schedule shape), `filter_by_value`, daily calendar aggregation + both filters, `revrange`+`count 1`, `filter_by_ts` >128 slicing, and offset-cursor ordering. Confirms every routing variant returns identical results when batched — consumers can now batch schedule-filtered queries.
+
 ## Unreleased
 * Add Ruby 3.4 to build matrix (#89)
 

--- a/lib/redis/time_series/version.rb
+++ b/lib/redis/time_series/version.rb
@@ -2,6 +2,6 @@
 
 class Redis
   class TimeSeries
-    VERSION = "0.8.12"
+    VERSION = "0.8.13"
   end
 end

--- a/spec/redis/time_series/range_cmd_batch_spec.rb
+++ b/spec/redis/time_series/range_cmd_batch_spec.rb
@@ -63,6 +63,162 @@ RSpec.describe Redis::TimeSeries::RangeCmd, ".batch" do
     expect(described_class.batch(cmds).size).to eq(10)
   end
 
+  it "matches single execution for filter_by_range (schedule-shaped), alone and mixed with a plain cmd" do
+    day = Time.parse("2024-01-01")
+    ts1.madd((0...48).to_h { |i| [day + i * 30 * 60, i] })
+    ts2.madd({ day => 1, day + 1.hour => 2 })
+
+    open_ranges = [(day + 9.hours)..(day + 12.hours), (day + 13.hours)..(day + 17.hours)]
+    build_filtered = lambda do
+      rc = described_class.new(timeseries: ts1, start_time: day, end_time: day + 1.day)
+      rc.filter_by_range = open_ranges
+      rc
+    end
+    build_plain = -> { described_class.new(timeseries: ts2, start_time: day, end_time: day + 1.day) }
+
+    expected_filtered = build_filtered.call.cmd
+    expected_plain = build_plain.call.cmd
+
+    expect_any_instance_of(Redis).to receive(:pipelined).once.and_call_original
+    batch_result = described_class.batch([build_filtered.call, build_plain.call])
+
+    expect(sample_pair(batch_result[0])).to eq(sample_pair(expected_filtered))
+    expect(batch_result[0]).not_to be_empty
+    expect(sample_pair(batch_result[1])).to eq(sample_pair(expected_plain))
+  end
+
+  it "matches single execution for filter_by_value, plain and combined with aggregation" do
+    base = Time.parse("2024-01-01")
+    ts1.madd({ base => 1, base + 1.minute => 5, base + 2.minutes => 9, base + 3.minutes => 4 })
+
+    build_plain = lambda do
+      rc = described_class.new(timeseries: ts1, start_time: base, end_time: base + 1.hour)
+      rc.filter_by_value = [3, 8]
+      rc
+    end
+    build_agg = lambda do
+      rc = described_class.new(timeseries: ts1, start_time: base, end_time: base + 1.hour)
+      rc.filter_by_value = [3, 8]
+      rc.aggregation = ["count", 3_600_000]
+      rc
+    end
+
+    expected_plain = build_plain.call.cmd
+    expected_agg = build_agg.call.cmd
+
+    expect_any_instance_of(Redis).to receive(:pipelined).once.and_call_original
+    batch_result = described_class.batch([build_plain.call, build_agg.call])
+
+    expect(sample_pair(batch_result[0])).to eq(sample_pair(expected_plain))
+    expect(batch_result[0]).not_to be_empty
+    expect(sample_pair(batch_result[1])).to eq(sample_pair(expected_agg))
+    expect(batch_result[1]).not_to be_empty
+  end
+
+  # The comfort-monitoring shape: heaviest fan-out in production (daily calendar slicing × schedule sub-ranges).
+  it "matches single execution for daily calendar aggregation + filter_by_range + filter_by_value in a batch" do
+    start_time = Time.parse("2024-01-01")
+    end_time = Time.parse("2024-01-04")
+    ts1.madd((0...72).to_h { |h| [start_time + h.hours, h % 24] })
+    ts2.madd({ start_time => 1, start_time + 1.day => 2 })
+
+    open_ranges = (0..2).map { |d| (start_time + d.days + 9.hours)..(start_time + d.days + 17.hours) }
+    build_comfort = lambda do
+      rc = described_class.new(timeseries: ts1, start_time: start_time, end_time: end_time)
+      rc.aggregation = ["count", 86_400_000]
+      rc.filter_by_range = open_ranges
+      rc.filter_by_value = [10, 16]
+      rc
+    end
+    build_other = -> { described_class.new(timeseries: ts2, start_time: start_time, end_time: end_time) }
+
+    expected_comfort = build_comfort.call.cmd
+    expected_other = build_other.call.cmd
+
+    expect_any_instance_of(Redis).to receive(:pipelined).once.and_call_original
+    batch_result = described_class.batch([build_comfort.call, build_other.call])
+
+    expect(sample_pair(batch_result[0])).to eq(sample_pair(expected_comfort))
+    expect(batch_result[0]).not_to be_empty
+    expect(sample_pair(batch_result[1])).to eq(sample_pair(expected_other))
+  end
+
+  it "matches single execution and TS.GET for the revrange + count 1 last-sample shape" do
+    base = Time.parse("2024-01-01")
+    ts1.madd({ base => 1, base + 1.minute => 2, base + 2.minutes => 3 })
+
+    build = lambda do
+      rc = described_class.new(timeseries: ts1)
+      rc.revrange
+      rc.count = 1
+      rc
+    end
+
+    expected = build.call.cmd
+    last = ts1.get
+
+    expect_any_instance_of(Redis).to receive(:pipelined).once.and_call_original
+    batch_result = described_class.batch([build.call])
+
+    expect(sample_pair(batch_result[0])).to eq(sample_pair(expected))
+    expect(batch_result[0].first.time).to eq(last.time)
+    expect(batch_result[0].first.value).to eq(last.value)
+  end
+
+  it "slices filter_by_ts beyond 128 timestamps inside a batch without disturbing neighbors" do
+    base = Time.parse("2024-01-01")
+    times = (0...150).map { |i| base + i.minutes }
+    ts1.madd(times.each_with_index.to_h { |t, i| [t, i] })
+    ts2.madd({ base => 1 })
+
+    filter_ts = times.map { |t| t.to_i * 1000 }
+    build_filtered = lambda do
+      rc = described_class.new(timeseries: ts1, start_time: base, end_time: base + 1.day)
+      rc.filter_by_ts = filter_ts
+      rc
+    end
+    build_plain = -> { described_class.new(timeseries: ts2, start_time: base, end_time: base + 1.day) }
+
+    expected_filtered = build_filtered.call.cmd
+    expected_plain = build_plain.call.cmd
+
+    expect_any_instance_of(Redis).to receive(:pipelined).once.and_call_original
+    batch_result = described_class.batch([build_filtered.call, build_plain.call])
+
+    expect(sample_pair(batch_result[0])).to eq(sample_pair(expected_filtered))
+    expect(batch_result[0].size).to eq(150)
+    expect(sample_pair(batch_result[1])).to eq(sample_pair(expected_plain))
+  end
+
+  it "keeps the offset cursor aligned across fan-out, plain, fan-out ordering" do
+    jan = Time.parse("2024-01-01")
+    apr = Time.parse("2024-04-01")
+    ts1.madd({ jan => 10, Time.parse("2024-02-01") => 20, Time.parse("2024-03-01") => 30 })
+    ts2.madd({ jan => 1, jan + 1.hour => 2 })
+
+    build_monthly = lambda do
+      rc = described_class.new(timeseries: ts1, start_time: jan, end_time: apr)
+      rc.aggregation = ["avg", 2_629_746_000]
+      rc
+    end
+    build_plain = -> { described_class.new(timeseries: ts2, start_time: jan, end_time: apr) }
+    build_ranged = lambda do
+      rc = described_class.new(timeseries: ts1, start_time: jan, end_time: apr)
+      rc.filter_by_range = [jan..(jan + 1.day), Time.parse("2024-02-01")..Time.parse("2024-02-02")]
+      rc
+    end
+
+    expected = [build_monthly.call.cmd, build_plain.call.cmd, build_ranged.call.cmd]
+
+    expect_any_instance_of(Redis).to receive(:pipelined).once.and_call_original
+    batch_result = described_class.batch([build_monthly.call, build_plain.call, build_ranged.call])
+
+    batch_result.each_with_index do |samples, i|
+      expect(sample_pair(samples)).to eq(sample_pair(expected[i]))
+      expect(samples).not_to be_empty
+    end
+  end
+
   it "handles a mix of routing variants in a single pipeline" do
     timestamp1 = Time.parse("2024-01-01")
     timestamp2 = Time.parse("2024-02-01")


### PR DESCRIPTION
## Release 1 of 3 — RangeCmd.batch adoption

Six new batch-vs-single parity specs in `range_cmd_batch_spec.rb`, each asserting `RangeCmd.batch` returns exactly what the equivalent `#cmd` calls return, in one pipelined round trip:

1. `filter_by_range` (operational-schedule shape: multiple sub-ranges) alone and mixed with a plain cmd
2. `filter_by_value` plain and combined with aggregation
3. The comfort-monitoring shape: daily calendar aggregation + `filter_by_range` + `filter_by_value` (heaviest fan-out in production)
4. `revrange` + `COUNT 1` ("last sample"), parity vs `TS.GET`
5. `filter_by_ts` beyond the 128 limit sliced inside a batch without disturbing neighbours
6. Offset-cursor ordering stress: `[fan-out, plain, fan-out]`

All green with **no code change** — `#cmd` and `.batch` share the same `enqueue → route_to_pipeline` path, and the `CountingPipeline`/`PipelineResult` slot accounting (b9111cc/612e2aa) already handles per-cmd fan-out. These specs turn that from an architectural argument into a hard release gate.

**Why this matters:** the note in shared_models claiming `operational_schedule`/`filter_by_range` is batch-incompatible predates the 2026-05-20 batch redesign and is now provably stale. The follow-up shared_models/portals_engine PRs batch schedule-filtered queries and must not merge before this does.

Version bumped to 0.8.13. Suite: 220 examples, only the 4 failures that already fail on clean develop (Sample#time TZ, TimeWithZone TS.ADD, TS.INFO struct, CalculatedSample filter — all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)