### PR TITLE
RangeCmd: a missing series key resolves to empty Samples instead of failing the whole batch

### DIFF
--- a/lib/redis/time_series/range_cmd.rb
+++ b/lib/redis/time_series/range_cmd.rb
@@ -15,6 +15,11 @@ class Redis
       # Redis TimeSeries hard limit on FILTER_BY_TS list length.
       FILTER_BY_TS_LIMIT = 128
 
+      # Error reply for TS.RANGE/TS.REVRANGE against a non-existent key. Treated
+      # as "no data" so one lost series degrades to an empty result instead of
+      # failing a whole batched render; any other error is a real fault.
+      MISSING_KEY_MESSAGE = "TSDB: the key does not exist"
+
       attr_reader :command, :timeseries
       attr_accessor :filter_by_ts, :filter_by_range, :filter_by_value, :count, :align, :empty
 
@@ -68,10 +73,12 @@ class Redis
       # ─── 3. Single-command execution ──────────────────────────────────
 
       # Runs this RangeCmd on its own and returns a Samples object.
+      # exception: false so a missing key resolves to empty Samples (see
+      # PipelineResult#sanitize) instead of raising.
       def cmd
         handle = nil
         pipeline_result = @timeseries.redis.with do |conn|
-          conn.pipelined { |pipeline| handle = enqueue(pipeline) }
+          conn.pipelined(exception: false) { |pipeline| handle = enqueue(pipeline) }
         end
         handle.resolve(pipeline_result)
       end
@@ -96,8 +103,11 @@ class Redis
         return [] if range_cmds.empty?
 
         handles = []
+        # exception: false keeps per-slot errors in place: one missing series
+        # yields empty Samples for its own slot instead of failing every
+        # RangeCmd in the batch (see PipelineResult#sanitize).
         pipeline_result = range_cmds.first.timeseries.redis.with do |conn|
-          conn.pipelined do |pipeline|
+          conn.pipelined(exception: false) do |pipeline|
             range_cmds.each { |range_cmd| handles << range_cmd.enqueue(pipeline) }
           end
         end
@@ -188,6 +198,7 @@ class Redis
         #
         # Otherwise (daily aggregation, non-calendar paths) the slice is flattened one level; rows already carry their own timestamps and no NaN injection is needed.
         def resolve(slice)
+          slice = slice.map { |raw| sanitize(raw) }
           rows =
             if @empty && !queried_timestamps.empty?
               slice.each_with_index.map do |raw, i|
@@ -206,6 +217,18 @@ class Redis
 
           Samples.new(rows.filter_map { |timestamp, val| timestamp.nil? ? nil : Sample.new(timestamp, val) })
         end
+
+        private
+          # With pipelined(exception: false) a failed command surfaces as an
+          # error object in its slot. A missing series only means "no data"
+          # and becomes an empty reply; anything else is re-raised as
+          # Redis::CommandError — the class plain pipelined raised before, so
+          # callers' rescue contracts are unchanged.
+          def sanitize(raw)
+            return raw unless raw.is_a?(StandardError)
+            raise Redis::CommandError, raw.message unless raw.message.include?(MISSING_KEY_MESSAGE)
+            []
+          end
       end
 
       private

--- a/spec/redis/time_series/range_cmd_batch_spec.rb
+++ b/spec/redis/time_series/range_cmd_batch_spec.rb
@@ -63,6 +63,48 @@ RSpec.describe Redis::TimeSeries::RangeCmd, ".batch" do
     expect(described_class.batch(cmds).size).to eq(10)
   end
 
+  describe "missing series keys" do
+    let(:missing_ts) { Redis::TimeSeries.new("batch_range_test_missing") }
+
+    it "resolves a missing key to empty Samples without poisoning the other slots" do
+      timestamp1 = Time.parse("2024-01-01")
+      timestamp2 = Time.parse("2024-01-02")
+      ts1.madd({ timestamp1 => 10, timestamp2 => 20 })
+      ts2.madd({ timestamp1 => 100, timestamp2 => 200 })
+
+      cmds = [ts1, missing_ts, ts2].map { |series| described_class.new(timeseries: series, start_time: timestamp1, end_time: timestamp2) }
+      result = described_class.batch(cmds)
+
+      expect(sample_pair(result[0])).to eq([[timestamp1, 10.0], [timestamp2, 20.0]])
+      expect(result[1]).to be_empty
+      expect(sample_pair(result[2])).to eq([[timestamp1, 100.0], [timestamp2, 200.0]])
+    end
+
+    it "NaN-injects the expected buckets when a missing key is queried with a calendar aggregation" do
+      timestamp1 = Time.parse("2024-01-01")
+      timestamp2 = Time.parse("2024-04-01")
+
+      cmd = described_class.new(timeseries: missing_ts, start_time: timestamp1, end_time: timestamp2)
+      cmd.aggregation = ["avg", 2629746000]
+
+      result = described_class.batch([cmd]).first
+      expect(sample_pair(result)).to eq([
+        [Time.parse("2024-01-01"), :nan],
+        [Time.parse("2024-02-01"), :nan],
+        [Time.parse("2024-03-01"), :nan]
+      ])
+    end
+
+    it "still raises for errors other than a missing key" do
+      Redis::TimeSeries.redis.with { |conn| conn.set("batch_range_test_missing", "not a timeseries") }
+      cmd = described_class.new(timeseries: missing_ts, start_time: Time.parse("2024-01-01"), end_time: Time.parse("2024-01-02"))
+
+      expect { described_class.batch([cmd]) }.to raise_error(Redis::CommandError)
+    ensure
+      Redis::TimeSeries.redis.with { |conn| conn.del("batch_range_test_missing") }
+    end
+  end
+
   it "handles a mix of routing variants in a single pipeline" do
     timestamp1 = Time.parse("2024-01-01")
     timestamp2 = Time.parse("2024-02-01")

--- a/spec/redis/time_series/range_cmd_spec.rb
+++ b/spec/redis/time_series/range_cmd_spec.rb
@@ -33,6 +33,25 @@ RSpec.describe Redis::TimeSeries::RangeCmd do
       range.cmd
     end
 
+    context "when the series key does not exist" do
+      let(:missing_ts) { Redis::TimeSeries.new("range_test_missing_key") }
+
+      it "returns empty Samples instead of raising" do
+        cmd = described_class.new(timeseries: missing_ts, start_time: Time.parse("2024-01-01"), end_time: Time.parse("2024-01-02"))
+
+        expect(cmd.cmd).to be_empty
+      end
+
+      it "still raises for errors other than a missing key" do
+        Redis::TimeSeries.redis.with { |conn| conn.set("range_test_missing_key", "not a timeseries") }
+        cmd = described_class.new(timeseries: missing_ts, start_time: Time.parse("2024-01-01"), end_time: Time.parse("2024-01-02"))
+
+        expect { cmd.cmd }.to raise_error(Redis::CommandError)
+      ensure
+        Redis::TimeSeries.redis.with { |conn| conn.del("range_test_missing_key") }
+      end
+    end
+
     context "with an aggregation duration of 1.month" do
       it "returns an array of samples aggregated by the duration of that month" do
         timestamp1 = Time.parse("2024-01-01")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,9 @@ require 'redis-time-series'
 
 REDIS_PORT = ENV['REDIS_PORT'] || 9000
 REDIS_HOST = ENV['REDIS_HOST'] || '127.0.0.1'
-REDIS_PASSWORD = ENV['REDIS_PASSWORD'] || ""
+# nil (not "") when unset: redis-client sends AUTH for any non-nil password,
+# which errors against a passwordless Redis.
+REDIS_PASSWORD = ENV['REDIS_PASSWORD'].to_s.empty? ? nil : ENV['REDIS_PASSWORD']
 
 module RedisHelpers
   def redis


### PR DESCRIPTION
`TS.RANGE`/`TS.REVRANGE` against a non-existent key raised out of the shared pipeline: `RangeCmd#cmd` failed the single read, and `RangeCmd.batch` **poisoned every command in the batch** — one series whose key is missing (never created yet, or lost to a flush/restore) failed all the other range queries batched with it.

### Change
- `#cmd` and `.batch` run their pipeline with `pipelined(exception: false)`, so errors stay in their own reply slot.
- `PipelineResult` sanitizes each slot:
  - `TSDB: the key does not exist` → empty reply. A plain range yields empty `Samples`; a calendar aggregation with `empty` yields the usual NaN-injected buckets — a missing series behaves exactly like an empty one.
  - **Any other error re-raises as `Redis::CommandError`** — the same class plain `pipelined` raised, so caller rescue contracts are unchanged and real faults (WRONGTYPE, bad arguments) still surface instead of being silently swallowed.

### Also
`spec_helper`'s `REDIS_PASSWORD` now defaults to `nil` instead of `""` — redis-client sends `AUTH` for any non-nil password, which errors against a passwordless Redis and blocked running the suite locally.

### Testing
5 new examples against real Redis: missing-key `#cmd` → empty Samples; batch of `[live, missing, live]` → middle slot empty, neighbours intact; missing key under monthly calendar aggregation → NaN buckets; non-missing-key errors still raise (both paths). Full suite: 219 examples, only the 4 failures already failing on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)